### PR TITLE
Fix unkeyed literals in protobuf initialization

### DIFF
--- a/processor/context.go
+++ b/processor/context.go
@@ -309,7 +309,13 @@ func (self *Context) AddReceiptData(data []byte) error {
 func (self *Context) AddEvent(event_type string, attributes []Attribute, event_data []byte) error {
 	event_attributes := make([]*events_pb2.Event_Attribute, 0, len(attributes))
 	for _, attribute := range attributes {
-		event_attributes = append(event_attributes, &events_pb2.Event_Attribute{attribute.Key, attribute.Value})
+		event_attributes = append(
+			event_attributes,
+			&events_pb2.Event_Attribute{
+				Key:   attribute.Key,
+				Value: attribute.Value,
+			},
+		)
 	}
 
 	event := &events_pb2.Event{

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -61,7 +61,13 @@ func TestAddEvent(t *testing.T) {
 	context := processor.NewContext(connection, "asdf")
 
 	event_attributes := make([]*events_pb2.Event_Attribute, 0)
-	event_attributes = append(event_attributes, &events_pb2.Event_Attribute{"key", "value"})
+	event_attributes = append(
+		event_attributes,
+		&events_pb2.Event_Attribute{
+			Key:   "key",
+			Value: "value",
+		},
+	)
 
 	event := &events_pb2.Event{
 		EventType:  "test",


### PR DESCRIPTION
The golang/protobuf dependency update on 4/30 forces users to use keyed literals (e.g., foopb.Message{Name: "Golang", Age: 8} as opposed to foopb.Message{"Golang", 8}). There were a few examples of the latter that had to be updated.

https://groups.google.com/forum/#!topic/protobuf/N-elvFu4dFM
golang/protobuf#591

Signed-off-by: Darian Plumb dplumb@bitwise.io