### PR TITLE
fix sed errors when build on Mac

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -16,7 +16,7 @@ mkdir -p  protobuf mocks/mock_messaging
 # Update import paths on generated protos
 repourl=github.com/hyperledger/sawtooth-sdk-go
 grep -rl '"protobuf/' protobuf/ | while IFS= read -r file; do
-    sed -i "s|\"protobuf/|\"${repourl}/protobuf/|" "$file"
+    sed -i -e s"|\"protobuf/|\"${repourl}/protobuf/|" "$file"
 done
 
 (


### PR DESCRIPTION
This fix is from @oatmealraisin . On Mac OS X 10.13.4, `go generate` will give a list of errors:
```
sed: 1: "protobuf//consensus_pb2 ...": extra characters at the end of p command
sed: 1: "protobuf//setting_pb2/s ...": extra characters at the end of p command
sed: 1: "protobuf//client_receip ...": extra characters at the end of p command
sed: 1: "protobuf//client_peers_ ...": extra characters at the end of p command
sed: 1: "protobuf//network_pb2/n ...": extra characters at the end of p command
sed: 1: "protobuf//authorization ...": extra characters at the end of p command
sed: 1: "protobuf//client_transa ...": extra characters at the end of p command
sed: 1: "protobuf//genesis_pb2/g ...": extra characters at the end of p command
sed: 1: "protobuf//client_event_ ...": extra characters at the end of p command
sed: 1: "protobuf//identity_pb2/ ...": extra characters at the end of p command
sed: 1: "protobuf//client_batch_ ...": extra characters at the end of p command
sed: 1: "protobuf//processor_pb2 ...": extra characters at the end of p command
sed: 1: "protobuf//block_pb2/blo ...": extra characters at the end of p command
sed: 1: "protobuf//merkle_pb2/me ...": extra characters at the end of p command
sed: 1: "protobuf//transaction_r ...": extra characters at the end of p command
sed: 1: "protobuf//events_pb2/ev ...": extra characters at the end of p command
sed: 1: "protobuf//client_batch_ ...": extra characters at the end of p command
sed: 1: "protobuf//client_list_c ...": extra characters at the end of p command
sed: 1: "protobuf//client_state_ ...": extra characters at the end of p command
sed: 1: "protobuf//client_block_ ...": extra characters at the end of p command
sed: 1: "protobuf//transaction_p ...": extra characters at the end of p command
sed: 1: "protobuf//batch_pb2/bat ...": extra characters at the end of p command
sed: 1: "protobuf//client_status ...": extra characters at the end of p command
sed: 1: "protobuf//validator_pb2 ...": extra characters at the end of p command
sed: 1: "protobuf//state_context ...": extra characters at the end of p command
```
And this fix works on both Linux (gnu sed) and Mac (bsd sed)