### PR TITLE
Fix finding the handler

### DIFF
--- a/processor/worker.go
+++ b/processor/worker.go
@@ -119,7 +119,7 @@ func worker(context *zmq.Context, uri string, queue <-chan *validator_pb2.Messag
 func findHandler(handlers []TransactionHandler, header *transaction_pb2.TransactionHeader) (TransactionHandler, error) {
 	for _, handler := range handlers {
 		if header.GetFamilyName() != handler.FamilyName() {
-			break
+			continue
 		}
 
 		HeaderVersion := header.GetFamilyVersion()

--- a/processor/worker.go
+++ b/processor/worker.go
@@ -19,6 +19,7 @@ package processor
 
 import (
 	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/sawtooth-sdk-go/messaging"
 	"github.com/hyperledger/sawtooth-sdk-go/protobuf/processor_pb2"
@@ -132,7 +133,7 @@ func findHandler(handlers []TransactionHandler, header *transaction_pb2.Transact
 		}
 
 		if !HasVersion {
-			break
+			continue
 		}
 
 		return handler, nil


### PR DESCRIPTION
Comparing to the Javascript SDK, we should not breaking the loop when the family name not match.
```
let handler = this._handlers.find(
            (candidate) =>
              candidate.transactionFamilyName === txnHeader.familyName &&
              candidate.versions.includes(txnHeader.familyVersion))
```