### PR TITLE
Go 1.10 Update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,12 @@ RUN apt-get update \
 LABEL "install-type"="mounted"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
+ && echo "deb http://archive.ubuntu.com/ubuntu bionic-updates universe" >> /etc/apt/sources.list \
  && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
-    golang-1.9-go \
+    golang-1.10-go \
     git \
     libssl-dev \
     libzmq3-dev \
@@ -52,7 +53,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >>
 
 ENV GOPATH=/go
 
-ENV PATH=$PATH:/go/bin:/usr/lib/go-1.9/bin
+ENV PATH=$PATH:/go/bin:/usr/lib/go-1.10/bin
 
 RUN mkdir /go
 

--- a/examples/intkey_go/Dockerfile-installed-bionic
+++ b/examples/intkey_go/Dockerfile-installed-bionic
@@ -24,7 +24,7 @@ RUN apt-get update \
  && apt-get install gnupg -y
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
- && echo "deb http://archive.ubuntu.com/ubuntu bionic-backports universe" >> /etc/apt/sources.list \
+ && echo "deb http://archive.ubuntu.com/ubuntu bionic-updates universe" >> /etc/apt/sources.list \
  && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \

--- a/examples/intkey_go/Dockerfile-installed-bionic
+++ b/examples/intkey_go/Dockerfile-installed-bionic
@@ -30,7 +30,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >>
  && apt-get update \
  && apt-get install -y -q \
     build-essential \
-    golang-1.9-go \
+    golang-1.10-go \
     git \
     libssl-dev \
     libzmq3-dev \
@@ -41,7 +41,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >>
 
 ENV GOPATH=/go:/go/src/github.com/hyperledger/sawtooth-sdk-go/:/go/src/github.com/hyperledger/sawtooth-sdk-go/examples/intkey_go
 
-ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.9/bin
+ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.10/bin
 
 RUN mkdir /go
 

--- a/examples/intkey_go/Dockerfile-installed-xenial
+++ b/examples/intkey_go/Dockerfile-installed-xenial
@@ -27,7 +27,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >>
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \
     build-essential \
-    golang-1.9-go \
+    golang-1.10-go \
     git \
     libssl-dev \
     libzmq3-dev \
@@ -38,7 +38,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >>
 
 ENV GOPATH=/go:/go/src/github.com/hyperledger/sawtooth-sdk-go/:/go/src/github.com/hyperledger/sawtooth-sdk-go/examples/intkey_go
 
-ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.9/bin
+ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.10/bin
 
 RUN mkdir /go
 

--- a/examples/intkey_go/intkey-tests.dockerfile
+++ b/examples/intkey_go/intkey-tests.dockerfile
@@ -25,8 +25,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/nightly bionic universe" >> /etc/ap
 RUN apt-get install -y -q \
     python3-sawtooth-integration \
     python3-sawtooth-intkey-tests \
-    python3-sawtooth-sdk \
-    python3-sawtooth-signing
+    python3-sawtooth-sdk
 
 RUN apt-get install -y -q --allow-downgrades \
     git \

--- a/examples/intkey_go/tests/test_intkey_smoke_go.yaml
+++ b/examples/intkey_go/tests/test_intkey_smoke_go.yaml
@@ -28,7 +28,7 @@ services:
     image: sawtooth-intkey-tp-go:$ISOLATION_ID
     build:
       context: ../../..
-      dockerfile: examples/intkey_go/Dockerfile-installed
+      dockerfile: examples/intkey_go/Dockerfile-installed-${DISTRO}
     depends_on:
       - validator
     command: intkey-tp-go -v -C tcp://validator:4004

--- a/examples/intkey_go/tests/test_tp_intkey_go.yaml
+++ b/examples/intkey_go/tests/test_tp_intkey_go.yaml
@@ -20,7 +20,7 @@ services:
   intkey-tp-go:
     build:
       context: ../../..
-      dockerfile: examples/intkey_go/Dockerfile-installed
+      dockerfile: examples/intkey_go/Dockerfile-installed-${DISTRO}
     image: sawtooth-intkey-tp-go:$ISOLATION_ID
     command: intkey-tp-go -vv -C tcp://test-intkey-tp-go:4004
     stop_signal: SIGKILL

--- a/examples/noop_go/Dockerfile-installed-bionic
+++ b/examples/noop_go/Dockerfile-installed-bionic
@@ -30,7 +30,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >>
  && apt-get update \
  && apt-get install -y -q \
     build-essential \
-    golang-1.9-go \
+    golang-1.10-go \
     git \
     libssl-dev \
     libzmq3-dev \
@@ -41,7 +41,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >>
 
 ENV GOPATH=/go:/go/src/github.com/hyperledger/sawtooth-sdk-go:/go/src/github.com/hyperledger/sawtooth-sdk-go/examples/noop_go/
 
-ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.9/bin
+ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.10/bin
 
 RUN mkdir /go
 

--- a/examples/noop_go/Dockerfile-installed-bionic
+++ b/examples/noop_go/Dockerfile-installed-bionic
@@ -24,7 +24,7 @@ RUN apt-get update \
  && apt-get install gnupg -y
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
- && echo "deb http://archive.ubuntu.com/ubuntu bionic-backports universe" >> /etc/apt/sources.list \
+ && echo "deb http://archive.ubuntu.com/ubuntu bionic-updates universe" >> /etc/apt/sources.list \
  && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \

--- a/examples/noop_go/Dockerfile-installed-xenial
+++ b/examples/noop_go/Dockerfile-installed-xenial
@@ -27,7 +27,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >>
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \
     build-essential \
-    golang-1.9-go \
+    golang-1.10-go \
     git \
     libssl-dev \
     libzmq3-dev \
@@ -38,7 +38,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >>
 
 ENV GOPATH=/go:/go/src/github.com/hyperledger/sawtooth-sdk-go:/go/src/github.com/hyperledger/sawtooth-sdk-go/examples/noop_go/
 
-ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.9/bin
+ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.10/bin
 
 RUN mkdir /go
 

--- a/examples/smallbank/smallbank_go/Dockerfile-installed-bionic
+++ b/examples/smallbank/smallbank_go/Dockerfile-installed-bionic
@@ -30,7 +30,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >>
  && apt-get update \
  && apt-get install -y -q \
     build-essential \
-    golang-1.9-go \
+    golang-1.10-go \
     git \
     libssl-dev \
     libzmq3-dev \
@@ -41,7 +41,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >>
 
 ENV GOPATH=/go:/project/:/go/src/github.com/hyperledger/sawtooth-sdk-go:/go/src/github.com/hyperledger/sawtooth-sdk-go/examples/smallbank/smallbank_go/
 
-ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.9/bin
+ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.10/bin
 
 RUN mkdir /go
 

--- a/examples/smallbank/smallbank_go/Dockerfile-installed-bionic
+++ b/examples/smallbank/smallbank_go/Dockerfile-installed-bionic
@@ -24,7 +24,7 @@ RUN apt-get update \
  && apt-get install gnupg -y
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
- && echo "deb http://archive.ubuntu.com/ubuntu bionic-backports universe" >> /etc/apt/sources.list \
+ && echo "deb http://archive.ubuntu.com/ubuntu bionic-updates universe" >> /etc/apt/sources.list \
  && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \

--- a/examples/smallbank/smallbank_go/Dockerfile-installed-xenial
+++ b/examples/smallbank/smallbank_go/Dockerfile-installed-xenial
@@ -27,7 +27,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >>
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \
     build-essential \
-    golang-1.9-go \
+    golang-1.10-go \
     git \
     libssl-dev \
     libzmq3-dev \
@@ -38,7 +38,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >>
 
 ENV GOPATH=/go:/project/:/go/src/github.com/hyperledger/sawtooth-sdk-go:/go/src/github.com/hyperledger/sawtooth-sdk-go/examples/smallbank/smallbank_go/
 
-ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.9/bin
+ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.10/bin
 
 RUN mkdir /go
 

--- a/examples/xo_go/Dockerfile-installed-bionic
+++ b/examples/xo_go/Dockerfile-installed-bionic
@@ -30,7 +30,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >>
  && apt-get update \
  && apt-get install -y -q \
     build-essential \
-    golang-1.9-go \
+    golang-1.10-go \
     git \
     libssl-dev \
     libzmq3-dev \
@@ -41,7 +41,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >>
 
 ENV GOPATH=/go:/go/src/github.com/hyperledger/sawtooth-sdk-go:/go/src/github.com/hyperledger/sawtooth-sdk-go/examples/xo_go
 
-ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.9/bin
+ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.10/bin
 
 RUN mkdir /go
 

--- a/examples/xo_go/Dockerfile-installed-bionic
+++ b/examples/xo_go/Dockerfile-installed-bionic
@@ -24,7 +24,7 @@ RUN apt-get update \
  && apt-get install gnupg -y
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
- && echo "deb http://archive.ubuntu.com/ubuntu bionic-backports universe" >> /etc/apt/sources.list \
+ && echo "deb http://archive.ubuntu.com/ubuntu bionic-updates universe" >> /etc/apt/sources.list \
  && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \

--- a/examples/xo_go/Dockerfile-installed-xenial
+++ b/examples/xo_go/Dockerfile-installed-xenial
@@ -27,7 +27,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >>
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \
     build-essential \
-    golang-1.9-go \
+    golang-1.10-go \
     git \
     libssl-dev \
     libzmq3-dev \
@@ -38,7 +38,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >>
 
 ENV GOPATH=/go:/go/src/github.com/hyperledger/sawtooth-sdk-go:/go/src/github.com/hyperledger/sawtooth-sdk-go/examples/xo_go
 
-ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.9/bin
+ENV PATH=$PATH:/project/bin:/go/bin:/usr/lib/go-1.10/bin
 
 RUN mkdir /go
 

--- a/examples/xo_go/tests/test_tp_xo_go.yaml
+++ b/examples/xo_go/tests/test_tp_xo_go.yaml
@@ -20,7 +20,7 @@ services:
   xo-tp-go:
     build:
       context: ../../..
-      dockerfile: examples/xo_go/Dockerfile-installed
+      dockerfile: examples/xo_go/Dockerfile-installed-${DISTRO}
     image: sawtooth-xo-tp-go:$ISOLATION_ID
     command: xo-tp-go -vv -C tcp://test-xo-tp-go:4004
     stop_signal: SIGKILL

--- a/examples/xo_go/tests/test_xo_smoke_go.yaml
+++ b/examples/xo_go/tests/test_xo_smoke_go.yaml
@@ -30,7 +30,7 @@ services:
     image: sawtooth-xo-tp-go:$ISOLATION_ID
     build:
       context: ../../..
-      dockerfile: examples/xo_go/Dockerfile-installed
+      dockerfile: examples/xo_go/Dockerfile-installed-${DISTRO}
     expose:
       - 4004
     depends_on:

--- a/examples/xo_go/xo-tests.dockerfile
+++ b/examples/xo_go/xo-tests.dockerfile
@@ -26,7 +26,6 @@ RUN apt-get install -y -q \
     python3-sawtooth-cli \
     python3-sawtooth-integration \
     python3-sawtooth-sdk \
-    python3-sawtooth-signing \
     python3-sawtooth-xo-tests
 
 RUN apt-get install -y -q --allow-downgrades \


### PR DESCRIPTION
Mocgen no longer supports go 1.9. This PR updates go to 1.10 as this is in both the xenial and bionic repositories.