### PR TITLE
Fix sawtooth-smallbank-tp-go to use defaults

### DIFF
--- a/examples/smallbank/smallbank_go/packaging/systemd/lib/systemd/system/sawtooth-smallbank-tp-go.service
+++ b/examples/smallbank/smallbank_go/packaging/systemd/lib/systemd/system/sawtooth-smallbank-tp-go.service
@@ -20,7 +20,7 @@ After=network.target
 [Service]
 User=sawtooth
 Group=sawtooth
-EnvironmentFile=-/etc/default/sawtooth-intkey-tp-go
+EnvironmentFile=-/etc/default/sawtooth-smallbank-tp-go
 ExecStart=/usr/bin/smallbank-tp-go $SAWTOOTH_SMALLBANK_TP_GO_ARGS
 Restart=on-failure
 


### PR DESCRIPTION
This systemd service file was referencing the intkey defaults file.

Signed-off-by: Richard Berg <rberg@bitwise.io>