### PR TITLE
Fix Docker instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Docker instructions
 ```
 cd sawtooth-sdk-go
 docker build . -t sawtooth-sdk-go
-docker run -v $(pwd):/project/sawtooth-sdk-go sawtooth-sdk-go
+docker run -v $(pwd):/go/src/github.com/hyperledger/sawtooth-sdk-go sawtooth-sdk-go
 ```
 
 Go generate will build the protos / mocks and place them in the protobuf or mocks directory respectively.


### PR DESCRIPTION
After following the Docker instructions in the README I kept getting this:

```
$ docker run -v $(pwd):/project/sawtooth-sdk-go sawtooth-sdk-go
can't load package: package github.com/hyperledger/sawtooth-sdk-go: no Go files in /go/src/github.com/hyperledger/sawtooth-sdk-go
```
then I realized that the reason why I kept getting the error was that the command in the README to build the SDK was mounting the volume to `/project/sawtooth-sdk-go` but the Dockerfile uses `/go/src/github.com/hyperledger/sawtooth-sdk-go/` as the working directory, and of course there are no files mounted in that path.