### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,13 +4,8 @@
 | Name | GitHub |
 | --- | --- |
 | Andi Gunderson | agunde406 |
-| Anne Chenette | chenette |
-| Cian Montgomery | cianx |
-| Dan Middleton | dcmiddle |
 | Darian Plumb | dplumb94 |
-| James Mitchell | jsmitchell |
 | Peter Schwarz | peterschwarz |
-| Richard Berg | rberg2 |
 | Ryan Beck-Buysse | rbuysse |
 | Shawn Amundson | vaporos |
 
@@ -18,7 +13,12 @@
 | Name | GitHub |
 | --- | --- |
 | Adam Ludvik | aludvik |
+| Anne Chenette | chenette |
 | Boyd Johnson | boydjohnson |
+| Cian Montgomery | cianx |
+| Dan Middleton | dcmiddle |
+| James Mitchell | jsmitchell |
 | Jamie Jason | jjason |
 | Nick Drozd | nick-drozd |
+| Richard Berg | rberg2 |
 | Zac Delventhal | delventhalz |


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>